### PR TITLE
supporting empty oneOf and anyOf

### DIFF
--- a/src/codegen.test.ts
+++ b/src/codegen.test.ts
@@ -79,4 +79,21 @@ describe("codegen", () => {
       });"
     `);
   });
+  it("generates schema with empty oneOf", () => {
+    const spec = {
+      components: {
+        schemas: {
+          Sample: {
+            oneOf: [],
+          },
+        },
+      },
+    };
+    const code = codegen(spec);
+    expect(code).toMatchInlineSnapshot(`
+      "import { z } from 'zod';
+
+      export const SampleSchema = z.never();"
+    `);
+  });
 });

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -108,6 +108,8 @@ class ZodSchemaCodeGenerator {
       }
       const lazySchema = schema as ZodSchemaWithDef<ZodLazyDef>;
       return `z.lazy(() => ${this.generateSchemaCode(lazySchema._def.getter(), schemaName)})`;
+    } else if (schema instanceof z.ZodNever) {
+      return "z.never()";
     }
     return "z.unknown()";
   }

--- a/src/converter.test.ts
+++ b/src/converter.test.ts
@@ -151,6 +151,25 @@ describe("OpenAPI to Zod Converter", () => {
     expect(parsedNumber.success).toBe(true);
   });
 
+  it("handles empty oneOf correctly", () => {
+    const spec = {
+      components: {
+        schemas: {
+          OneOfType: {
+            oneOf: [],
+          },
+        },
+      },
+    };
+
+    const zodSchemas = convertOpenAPISpecToZodSchemas(spec);
+    const OneOfTypeSchemaLazy = zodSchemas.map.OneOfType as z.ZodLazy<z.ZodNever>;
+    const OneOfTypeSchema = unwrapLazy(OneOfTypeSchemaLazy);
+
+    expect(OneOfTypeSchemaLazy).toBeInstanceOf(z.ZodLazy);
+    expect(OneOfTypeSchema).toBeInstanceOf(z.ZodNever);
+  });
+
   it("handles anyOf correctly", () => {
     const spec = {
       components: {
@@ -179,6 +198,25 @@ describe("OpenAPI to Zod Converter", () => {
     expect(parsed1.success).toBe(true);
     expect(parsed2.success).toBe(true);
     expect(parsedBoth.success).toBe(true);
+  });
+
+  it("handles empty anyOf correctly", () => {
+    const spec = {
+      components: {
+        schemas: {
+          AnyOfType: {
+            anyOf: [],
+          },
+        },
+      },
+    };
+
+    const zodSchemas = convertOpenAPISpecToZodSchemas(spec);
+    const AnyOfTypeSchemaLazy = zodSchemas.map.AnyOfType as z.ZodLazy<z.ZodNever>;
+    const AnyOfTypeSchema = unwrapLazy(AnyOfTypeSchemaLazy);
+
+    expect(AnyOfTypeSchemaLazy).toBeInstanceOf(z.ZodLazy);
+    expect(AnyOfTypeSchema).toBeInstanceOf(z.ZodNever);
   });
 
   it("handles nested schemas correctly", () => {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -110,6 +110,9 @@ class OpenAPIToZodConverter {
 
   private handleAnyOf(schemas: OpenAPISchema[]): z.ZodTypeAny {
     const convertedSchemas = schemas.map((s) => this.convertSchema(s));
+    if (convertedSchemas.length == 0) {
+      return z.never();
+    }
     if (convertedSchemas.length === 1) {
       return convertedSchemas[0];
     }


### PR DESCRIPTION
On empty oneOf or anyOf it is better to produce a `z.never()`.