### PR TITLE
better sequence of types on output

### DIFF
--- a/src/codegen.test.ts
+++ b/src/codegen.test.ts
@@ -48,7 +48,7 @@ describe("codegen", () => {
     `);
   });
 
-  it("generates schema with refs and lazy not generated schemes", () => {
+  it("generates schema with refs in a sequence which prevents lazy usage", () => {
     const spec = {
       components: {
         schemas: {
@@ -79,18 +79,18 @@ describe("codegen", () => {
     expect(code).toMatchInlineSnapshot(`
       "import { z } from 'zod';
 
-      export const PostSchema = z.object({
-        id: z.number(),
-        title: z.string(),
-        content: z.string(),
-        author: z.lazy(() => UserSchema)
-      });
-
       export const UserSchema = z.object({
         id: z.number(),
         name: z.string().optional(),
         email: z.string(),
         roles: z.array(z.string()).optional()
+      });
+
+      export const PostSchema = z.object({
+        id: z.number(),
+        title: z.string(),
+        content: z.string(),
+        author: UserSchema
       });"
     `);
   });

--- a/src/codegen.test.ts
+++ b/src/codegen.test.ts
@@ -48,6 +48,53 @@ describe("codegen", () => {
     `);
   });
 
+  it("generates schema with refs and lazy not generated schemes", () => {
+    const spec = {
+      components: {
+        schemas: {
+          Post: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              title: { type: "string" },
+              content: { type: "string" },
+              author: { $ref: "#/components/schemas/User" },
+            },
+            required: ["id", "title", "content", "author"],
+          },
+          User: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              name: { type: "string" },
+              email: { type: "string" },
+              roles: { type: "array", items: { type: "string" } },
+            },
+            required: ["id", "email"],
+          },
+        },
+      },
+    };
+    const code = codegen(spec);
+    expect(code).toMatchInlineSnapshot(`
+      "import { z } from 'zod';
+
+      export const PostSchema = z.object({
+        id: z.number(),
+        title: z.string(),
+        content: z.string(),
+        author: z.lazy(() => UserSchema)
+      });
+
+      export const UserSchema = z.object({
+        id: z.number(),
+        name: z.string().optional(),
+        email: z.string(),
+        roles: z.array(z.string()).optional()
+      });"
+    `);
+  });
+
   it("generates schema with nested objects and nullable properties", () => {
     const spec = {
       components: {

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -104,6 +104,9 @@ class ZodSchemaCodeGenerator {
         if (this.currentlyGenerating.has(referencedName)) {
           return `z.lazy(() => ${this.prefix}${referencedName}Schema)`;
         }
+        if (!this.generatedSchemas.has(referencedName)) {
+          return `z.lazy(() => ${this.prefix}${referencedName}Schema)`;
+        }
         return `${this.prefix}${referencedName}Schema`;
       }
       const lazySchema = schema as ZodSchemaWithDef<ZodLazyDef>;

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -115,9 +115,83 @@ class ZodSchemaCodeGenerator {
     return "z.unknown()";
   }
 
+  getReferencingSchemaNames(schema: z.ZodTypeAny): string[] {
+    let me = this;
+    function extractSchemaNames(schema: z.ZodTypeAny): string[] {
+      const result: string[] = [];
+      if (schema instanceof z.ZodObject) {
+        const shape = schema.shape;
+        return Object.entries(shape)
+          .map(([key, value]) => extractSchemaNames(value as z.ZodTypeAny))
+          .flat();
+      } else if (schema instanceof z.ZodArray) {
+        return extractSchemaNames(schema.element);
+      } else if (schema instanceof z.ZodUnion) {
+        const unionSchema = schema as ZodSchemaWithDef<ZodUnionDef>;
+        const options = unionSchema._def.options;
+        return options.map((schema) => extractSchemaNames(schema)).flat();
+      } else if (schema instanceof z.ZodNullable) {
+        return extractSchemaNames(schema.unwrap());
+      } else if (schema instanceof z.ZodOptional) {
+        return extractSchemaNames(schema.unwrap());
+      } else if (schema instanceof z.ZodLazy) {
+        const referencedName = Object.entries(me.schemas).find(([, s]) => s === schema)?.[0];
+        if (referencedName) {
+          return [referencedName];
+        }
+        const lazySchema = schema as ZodSchemaWithDef<ZodLazyDef>;
+        return extractSchemaNames(lazySchema._def.getter());
+      }
+      return result;
+    }
+
+    if (schema instanceof z.ZodLazy) {
+      const lazySchema = schema as ZodSchemaWithDef<ZodLazyDef>;
+      return extractSchemaNames(lazySchema._def.getter());
+    } else {
+      return extractSchemaNames(schema);
+    }
+  }
+
+  generateSchemaSequenceFrom(dependencyMap: Map<string, string[]>): string[] {
+    let result: string[] = [];
+
+    function processElement(targetPosition: number, name: string) {
+      let depdendencies = dependencyMap.get(name);
+      if (depdendencies == undefined) {
+        return 0;
+      }
+      dependencyMap.delete(name);
+      result.splice(targetPosition, 0, name);
+      let insertedElementCount = 0;
+      for (let dependency of depdendencies) {
+        let insertedElementCountByDependency = processElement(targetPosition, dependency);
+        targetPosition += insertedElementCountByDependency;
+        insertedElementCount += insertedElementCountByDependency;
+      }
+      return insertedElementCount + 1;
+    }
+
+    while (true) {
+      let first_entry = dependencyMap.entries().next();
+      if (first_entry.done) {
+        return result;
+      }
+      const [name] = first_entry.value;
+      processElement(result.length, name);
+    }
+  }
+
   generateCode(): string {
     const imports = `import { z } from 'zod';\n\n`;
-    const schemaDefinitions = Object.entries(this.schemas)
+    const schemasToGenerate = this.generateSchemaSequenceFrom(
+      Object.entries(this.schemas).reduce((dependencyMap, [name, schema]) => {
+        dependencyMap.set(name, this.getReferencingSchemaNames(schema));
+        return dependencyMap;
+      }, new Map<string, string[]>())
+    );
+    const schemaDefinitions = schemasToGenerate
+      .map((name) => [name, this.schemas[name]] as [string, z.ZodTypeAny])
       .map(([name, schema]) => {
         if (this.currentlyGenerating.has(name)) {
           return "";


### PR DESCRIPTION
To prevent the usage of `z.lazy` where it is possible a added a sorting of the types on code generating to respect the dependency graph of referenced types.